### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/rs-deviceid/security/code-scanning/1](https://github.com/microsoft/rs-deviceid/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block that explicitly grants the least privilege required to the workflow. Since none of the shown jobs or steps need to write to the contents of the repository or interact with GitHub APIs in a write capacity, the minimal permission required is `contents: read`. This should be added at the workflow root level, so it applies to all jobs unless overridden. Place the following immediately after the `name:` line and before the `on:` trigger.

No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
